### PR TITLE
feat: add cardano-addresses linux arm64 build infrastructure with binary-specific tagging

### DIFF
--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -3,7 +3,7 @@ name: Build Cardano Addresses
 on:
   push:
     tags:
-      - 'v*'
+      - 'cardano-addresses-v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -30,8 +30,14 @@ jobs:
         id: determine_tag
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            # Use the same tag from this repo for cardano-addresses
-            CARDANO_TAG="${{ github.ref_name }}"
+            # Extract version from binary-specific tag (e.g., cardano-addresses-v3.15.0 -> v3.15.0)
+            TAG_NAME="${{ github.ref_name }}"
+            if [[ "$TAG_NAME" == cardano-addresses-* ]]; then
+              CARDANO_TAG="${TAG_NAME#cardano-addresses-}"
+            else
+              echo "Error: Tag must start with 'cardano-addresses-'"
+              exit 1
+            fi
           else
             CARDANO_TAG="${{ github.event.inputs.tag }}"
           fi
@@ -81,6 +87,21 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
+      - name: Determine release tag
+        id: release_tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG_NAME="${{ github.ref_name }}"
+            if [[ "$TAG_NAME" == cardano-addresses-* ]]; then
+              CARDANO_TAG="${TAG_NAME#cardano-addresses-}"
+            else
+              CARDANO_TAG="$TAG_NAME"
+            fi
+          else
+            CARDANO_TAG="${{ github.event.inputs.tag }}"
+          fi
+          echo "cardano_tag=$CARDANO_TAG" >> $GITHUB_OUTPUT
+          
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -93,11 +114,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          name: Cardano Addresses ${{ github.event.inputs.tag || github.ref_name }}
+          name: Cardano Addresses ${{ steps.release_tag.outputs.cardano_tag }}
           body: |
             ## Cardano Addresses Binary Release
             
             This release contains the `cardano-addresses` binary compiled for various platforms.
+            Built from IntersectMBO/cardano-addresses tag: `${{ steps.release_tag.outputs.cardano_tag }}`
             
             ### Linux ARM64 (Raspberry Pi)
             - `cardano-addresses-linux-arm64.tar.gz` - Binary for Linux ARM64
@@ -115,6 +137,12 @@ jobs:
             ```bash
             cardano-addresses --help
             ```
+            
+            ### Release Notes
+            This binary was built using:
+            - GHC 9.10
+            - Cabal 3.12.1.0 
+            - Static linking for maximum portability
           files: |
             artifacts/**/*
           draft: false

--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -1,0 +1,123 @@
+name: Build Cardano Addresses
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Cardano Addresses tag/branch to build (e.g., v3.15.0)'
+        required: true
+        default: 'master'
+      ghc_version:
+        description: 'GHC version to use'
+        required: false
+        default: '9.10'
+      cabal_version:
+        description: 'Cabal version to use'
+        required: false
+        default: '3.12.1.0'
+
+jobs:
+  build-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine cardano-addresses tag
+        id: determine_tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Use the same tag from this repo for cardano-addresses
+            CARDANO_TAG="${{ github.ref_name }}"
+          else
+            CARDANO_TAG="${{ github.event.inputs.tag }}"
+          fi
+          echo "cardano_tag=$CARDANO_TAG" >> $GITHUB_OUTPUT
+          echo "Building cardano-addresses from tag/branch: $CARDANO_TAG"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build cardano-addresses for Linux ARM64
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg CARDANO_ADDRESSES_TAG=${{ steps.determine_tag.outputs.cardano_tag }} \
+            --build-arg GHC_VERSION=${{ github.event.inputs.ghc_version || '9.10' }} \
+            --build-arg CABAL_VERSION=${{ github.event.inputs.cabal_version || '3.12.1.0' }} \
+            -f Dockerfile.cardano-addresses-linux-arm64 \
+            -t cardano-addresses-builder \
+            --load .
+
+      - name: Extract binary from container
+        run: |
+          mkdir -p artifacts
+          docker run --rm -v $(pwd)/artifacts:/output cardano-addresses-builder sh -c "cp /usr/local/bin/cardano-addresses /output/"
+          
+      - name: Verify binary
+        run: |
+          file artifacts/cardano-addresses
+          ls -la artifacts/
+
+      - name: Compress binary
+        run: |
+          cd artifacts
+          tar -czf cardano-addresses-linux-arm64.tar.gz cardano-addresses
+          sha256sum cardano-addresses-linux-arm64.tar.gz > cardano-addresses-linux-arm64.tar.gz.sha256
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cardano-addresses-linux-arm64
+          path: |
+            artifacts/cardano-addresses-linux-arm64.tar.gz
+            artifacts/cardano-addresses-linux-arm64.tar.gz.sha256
+
+  release:
+    needs: build-linux-arm64
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display structure of downloaded files
+        run: find artifacts -type f
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: Cardano Addresses ${{ github.event.inputs.tag || github.ref_name }}
+          body: |
+            ## Cardano Addresses Binary Release
+            
+            This release contains the `cardano-addresses` binary compiled for various platforms.
+            
+            ### Linux ARM64 (Raspberry Pi)
+            - `cardano-addresses-linux-arm64.tar.gz` - Binary for Linux ARM64
+            - `cardano-addresses-linux-arm64.tar.gz.sha256` - SHA256 checksum
+            
+            ### Installation
+            
+            1. Download the appropriate binary for your platform
+            2. Verify the checksum: `sha256sum -c cardano-addresses-linux-arm64.tar.gz.sha256`
+            3. Extract: `tar -xzf cardano-addresses-linux-arm64.tar.gz`
+            4. Make executable: `chmod +x cardano-addresses`
+            5. Move to PATH: `sudo mv cardano-addresses /usr/local/bin/`
+            
+            ### Usage
+            ```bash
+            cardano-addresses --help
+            ```
+          files: |
+            artifacts/**/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.cardano-addresses-linux-arm64
+++ b/Dockerfile.cardano-addresses-linux-arm64
@@ -1,0 +1,74 @@
+FROM --platform=linux/arm64 ubuntu:22.04
+
+# Build arguments for version control
+ARG CARDANO_ADDRESSES_TAG=master
+ARG GHC_VERSION=9.10
+ARG CABAL_VERSION=3.12.1.0
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    automake \
+    build-essential \
+    pkg-config \
+    libffi-dev \
+    libgmp-dev \
+    libssl-dev \
+    libtinfo-dev \
+    libsystemd-dev \
+    zlib1g-dev \
+    make \
+    g++ \
+    tmux \
+    git \
+    jq \
+    wget \
+    libncursesw5 \
+    libtool \
+    autoconf \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GHC and Cabal
+RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+ENV PATH="/root/.ghcup/bin:$PATH"
+
+# Install specific versions used by IntersectMBO
+RUN ghcup install ghc ${GHC_VERSION} && \
+    ghcup set ghc ${GHC_VERSION} && \
+    ghcup install cabal ${CABAL_VERSION} && \
+    ghcup set cabal ${CABAL_VERSION}
+
+# Clone the cardano-addresses repository at specific tag/branch
+WORKDIR /build
+RUN git clone https://github.com/IntersectMBO/cardano-addresses.git && \
+    cd cardano-addresses && \
+    git checkout ${CARDANO_ADDRESSES_TAG}
+
+WORKDIR /build/cardano-addresses
+
+# Configure cabal to use system dependencies
+RUN cabal configure --enable-executable-static
+
+# Update cabal and build
+RUN cabal update && \
+    cabal build cardano-addresses
+
+# Copy the built binary to a known location
+RUN mkdir -p /output && \
+    cp $(cabal list-bin cardano-addresses) /output/cardano-addresses
+
+# Verify the binary works
+RUN /output/cardano-addresses --version
+
+# Create final minimal image
+FROM --platform=linux/arm64 ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    libgmp10 \
+    libssl3 \
+    libtinfo6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=0 /output/cardano-addresses /usr/local/bin/cardano-addresses
+RUN chmod +x /usr/local/bin/cardano-addresses
+
+CMD ["cardano-addresses", "--version"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # Cardano Binaries
+
+Cross-platform binary releases for Cardano ecosystem tools.
+
+## Available Binaries
+
+- **cardano-addresses** - Address derivation and validation tool for Linux ARM64 (Raspberry Pi)
+
+## Release System
+
+This repository uses binary-specific tags to trigger builds for individual tools:
+
+### Tag Format
+```
+<binary-name>-v<version>
+```
+
+### Examples
+- `cardano-addresses-v3.15.0` - Builds cardano-addresses version 3.15.0
+- `cardano-cli-v8.20.0` - Would build cardano-cli version 8.20.0 (when implemented)
+- `cardano-node-v8.9.0` - Would build cardano-node version 8.9.0 (when implemented)
+
+### How It Works
+1. **Tag Push**: Push a binary-specific tag (e.g., `cardano-addresses-v3.15.0`)
+2. **Version Extraction**: The workflow extracts the version (`v3.15.0`) from the tag
+3. **Source Checkout**: Checks out the corresponding tag from the IntersectMBO repository
+4. **Build**: Builds the binary using the recommended GHC/Cabal versions
+5. **Release**: Creates a GitHub release with the compiled binaries
+
+### Usage
+```bash
+# Release cardano-addresses v3.15.0
+git tag cardano-addresses-v3.15.0
+git push origin cardano-addresses-v3.15.0
+
+# This will:
+# 1. Trigger the cardano-addresses workflow
+# 2. Build from IntersectMBO/cardano-addresses tag v3.15.0
+# 3. Create release with ARM64 binaries
+```
+
+## Supported Platforms
+
+| Binary | Linux ARM64 | Linux x64 | macOS ARM64 | macOS x64 | Windows x64 |
+|--------|-------------|-----------|-------------|-----------|-------------|
+| cardano-addresses | ✅ | 🚧 | 🚧 | 🚧 | 🚧 |
+
+Legend: ✅ Available, 🚧 Planned, ❌ Not supported


### PR DESCRIPTION
## Summary
- Add Docker-based build system for cardano-addresses targeting Linux ARM64 (Raspberry Pi)
- Implement GitHub Actions workflow for automated builds and releases
- Add binary-specific tagging system to enable independent releases for different tools

## Features
- **Multi-platform Docker build** using official IntersectMBO cardano-addresses repository
- **Binary-specific tagging** - Use `cardano-addresses-v3.15.0` to build only cardano-addresses
- **Version synchronization** - Automatically builds from corresponding IntersectMBO tag
- **Latest toolchain** - Uses GHC 9.10 and Cabal 3.12.1.0 as recommended by IntersectMBO
- **Static linking** for portable ARM64 binaries
- **Automated releases** with checksums and installation instructions

## Tag System
- **Format**: `<binary-name>-v<version>`
- **Example**: `cardano-addresses-v3.15.0` triggers cardano-addresses build from IntersectMBO v3.15.0
- **Scalable**: Future binaries can use `cardano-cli-v*`, `cardano-node-v*` without conflicts

## Test plan
- [ ] Test Docker build locally with `docker buildx build --platform linux/arm64 -f Dockerfile.cardano-addresses-linux-arm64 .`
- [ ] Test tag trigger with `git tag cardano-addresses-v3.15.0 && git push origin cardano-addresses-v3.15.0`
- [ ] Verify binary runs on ARM64 systems
- [ ] Validate release artifacts and checksums

🤖 Generated with [Claude Code](https://claude.ai/code)