### PR TITLE
fix: correct GHC version to 9.10.1 and update documentation

### DIFF
--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -13,7 +13,7 @@ on:
       ghc_version:
         description: 'GHC version to use'
         required: false
-        default: '9.10'
+        default: '9.10.1'
       cabal_version:
         description: 'Cabal version to use'
         required: false
@@ -52,7 +52,7 @@ jobs:
           docker buildx build \
             --platform linux/arm64 \
             --build-arg CARDANO_ADDRESSES_TAG=${{ steps.determine_tag.outputs.cardano_tag }} \
-            --build-arg GHC_VERSION=${{ github.event.inputs.ghc_version || '9.10' }} \
+            --build-arg GHC_VERSION=${{ github.event.inputs.ghc_version || '9.10.1' }} \
             --build-arg CABAL_VERSION=${{ github.event.inputs.cabal_version || '3.12.1.0' }} \
             -f Dockerfile.cardano-addresses-linux-arm64 \
             -t cardano-addresses-builder \
@@ -140,7 +140,7 @@ jobs:
             
             ### Release Notes
             This binary was built using:
-            - GHC 9.10
+            - GHC 9.10.1
             - Cabal 3.12.1.0 
             - Static linking for maximum portability
           files: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# Claude AI Instructions for Cardano Binaries
+
+This file contains project-specific instructions for AI assistants working on this repository.
+
+## Project Overview
+
+This repository builds cross-platform binaries for Cardano ecosystem tools using Docker and GitHub Actions. Each binary has its own release cycle triggered by binary-specific tags.
+
+## Key Conventions
+
+### Tagging System
+- **Format**: `<binary-name>-v<version>`
+- **Examples**: `cardano-addresses-v4.0.0`, `cardano-cli-v8.20.0`
+- **Purpose**: Enables independent releases for each binary
+
+### File Naming
+- **Dockerfiles**: `Dockerfile.<binary-name>-<platform>` (e.g., `Dockerfile.cardano-addresses-linux-arm64`)
+- **Workflows**: `.github/workflows/build-<binary-name>.yml`
+- **Artifacts**: `<binary-name>-<platform>.tar.gz`
+
+### Merge Policy
+- **ALL PRs must be squash merged** to maintain clean commit history
+- Use conventional commit messages (`feat:`, `fix:`, `docs:`, etc.)
+
+## Development Guidelines
+
+### Adding New Binaries
+1. Research the source repository (usually IntersectMBO/<binary-name>)
+2. Check their CI/build requirements for GHC/Cabal versions
+3. Create platform-specific Dockerfile with build args for versions
+4. Create GitHub workflow with binary-specific tag trigger
+5. Update README.md with new binary information
+6. Test with actual version tag
+
+### Version Management
+- Always use the latest stable versions from upstream repositories
+- Check IntersectMBO repositories for recommended GHC/Cabal versions
+- Use build arguments in Dockerfiles for flexibility
+
+### Testing
+- Test Docker builds locally when possible: `docker buildx build --platform <platform> -f Dockerfile.<name> .`
+- Verify tag triggers work with real version tags
+- Confirm binaries are statically linked and portable
+
+## Current Status
+
+### Implemented
+- ✅ cardano-addresses (Linux ARM64)
+- ✅ Binary-specific tagging system
+- ✅ Automated GitHub releases
+
+### Planned
+- 🚧 cardano-addresses (Linux x64, macOS ARM64, macOS x64, Windows x64)
+- 🚧 cardano-cli (all platforms)
+- 🚧 cardano-node (all platforms)
+
+## Important Notes
+
+- This project focuses on PORTABLE, STATICALLY LINKED binaries
+- Each binary maintains independent release cycles
+- All workflows use multi-stage Docker builds for smaller final images
+- Checksums (SHA256) are automatically generated for all releases
+- Follow IntersectMBO's recommended toolchain versions
+
+## When Working on This Project
+
+1. Always check for latest versions of upstream binaries
+2. Test tag-based builds before merging
+3. Update documentation when adding new features
+4. Ensure squash merge is used for all PRs
+5. Verify static linking works for portability

--- a/Dockerfile.cardano-addresses-linux-arm64
+++ b/Dockerfile.cardano-addresses-linux-arm64
@@ -2,7 +2,7 @@ FROM --platform=linux/arm64 ubuntu:22.04
 
 # Build arguments for version control
 ARG CARDANO_ADDRESSES_TAG=master
-ARG GHC_VERSION=9.10
+ARG GHC_VERSION=9.10.1
 ARG CABAL_VERSION=3.12.1.0
 
 # Install build dependencies

--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ This repository uses binary-specific tags to trigger builds for individual tools
 ```
 
 ### Examples
-- `cardano-addresses-v3.15.0` - Builds cardano-addresses version 3.15.0
+- `cardano-addresses-v4.0.0` - Builds cardano-addresses version 4.0.0 (latest)
 - `cardano-cli-v8.20.0` - Would build cardano-cli version 8.20.0 (when implemented)
 - `cardano-node-v8.9.0` - Would build cardano-node version 8.9.0 (when implemented)
 
 ### How It Works
-1. **Tag Push**: Push a binary-specific tag (e.g., `cardano-addresses-v3.15.0`)
-2. **Version Extraction**: The workflow extracts the version (`v3.15.0`) from the tag
+1. **Tag Push**: Push a binary-specific tag (e.g., `cardano-addresses-v4.0.0`)
+2. **Version Extraction**: The workflow extracts the version (`v4.0.0`) from the tag
 3. **Source Checkout**: Checks out the corresponding tag from the IntersectMBO repository
 4. **Build**: Builds the binary using the recommended GHC/Cabal versions
 5. **Release**: Creates a GitHub release with the compiled binaries
 
 ### Usage
 ```bash
-# Release cardano-addresses v3.15.0
-git tag cardano-addresses-v3.15.0
-git push origin cardano-addresses-v3.15.0
+# Release cardano-addresses v4.0.0 (latest)
+git tag cardano-addresses-v4.0.0
+git push origin cardano-addresses-v4.0.0
 
 # This will:
 # 1. Trigger the cardano-addresses workflow
-# 2. Build from IntersectMBO/cardano-addresses tag v3.15.0
+# 2. Build from IntersectMBO/cardano-addresses tag v4.0.0
 # 3. Create release with ARM64 binaries
 ```
 
@@ -46,3 +46,39 @@ git push origin cardano-addresses-v3.15.0
 | cardano-addresses | ✅ | 🚧 | 🚧 | 🚧 | 🚧 |
 
 Legend: ✅ Available, 🚧 Planned, ❌ Not supported
+
+## Contributing
+
+We welcome contributions to add support for more binaries and platforms!
+
+### Development Workflow
+
+1. **Fork and Clone**: Fork this repository and clone your fork
+2. **Create Feature Branch**: `git checkout -b feat/your-feature-name`
+3. **Make Changes**: Add new Dockerfiles, workflows, or improvements
+4. **Test Locally**: Build and test your changes locally when possible
+5. **Commit**: Use conventional commits (e.g., `feat:`, `fix:`, `docs:`)
+6. **Create PR**: Open a pull request against the `main` branch
+7. **Squash Merge**: All PRs should be **squash merged** to maintain clean commit history
+
+### Adding New Binaries
+
+To add support for a new Cardano binary:
+
+1. Create `Dockerfile.<binary-name>-<platform>` (e.g., `Dockerfile.cardano-cli-linux-arm64`)
+2. Create `.github/workflows/build-<binary-name>.yml` workflow
+3. Use binary-specific tag pattern: `<binary-name>-v*`
+4. Update this README with the new binary information
+5. Test with a version tag (e.g., `cardano-cli-v8.20.0`)
+
+### PR Requirements
+
+- ✅ **Squash merge required** - Maintains clean commit history
+- ✅ Use conventional commit messages
+- ✅ Test builds locally when possible  
+- ✅ Update documentation for new features
+- ✅ Follow existing patterns and conventions
+
+### Questions?
+
+Open an issue for questions about contributing or adding new binary support.


### PR DESCRIPTION
## Summary
- Fix GHC version from 9.10 to 9.10.1 to resolve ghcup compatibility issue
- Update workflow and documentation to reflect correct version numbers
- Add comprehensive contribution guide and CLAUDE.md for project conventions

## Problem
The current build is failing because ghcup doesn't recognize "9.10" as a valid version. The logs show it's downloading GHC 9.6.7 instead of the intended 9.10.x version.

## Solution
- **Dockerfile**: Use correct GHC version `9.10.1`
- **Workflow**: Update default values to `9.10.1`
- **Documentation**: Add contribution guide with squash merge requirement
- **CLAUDE.md**: Project-specific instructions for AI assistance

## Test plan
- [ ] Verify new tag build uses correct GHC 9.10.1
- [ ] Confirm build completes successfully
- [ ] Validate binary works on ARM64 systems

## Fixes Issue
Resolves the GHC version installation failure in GitHub Actions build.

🤖 Generated with [Claude Code](https://claude.ai/code)