### PR TITLE
Fix: Use native ARM64 runners for builds

### DIFF
--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
@@ -35,15 +35,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Test build cardano-addresses for Linux x64 (no emulation)
+      - name: Test build cardano-addresses for Linux ARM64
         run: |
           docker buildx build \
-            --platform linux/amd64 \
             --build-arg CARDANO_ADDRESSES_TAG=4.0.0 \
             --build-arg GHC_VERSION=9.10.1 \
             --build-arg CABAL_VERSION=3.12.1.0 \
-            --cache-from=type=gha,scope=test-amd64 \
-            --cache-to=type=gha,mode=max,scope=test-amd64 \
+            --cache-from=type=gha,scope=test-arm64 \
+            --cache-to=type=gha,mode=max,scope=test-arm64 \
             -f Dockerfile.cardano-addresses-linux-arm64 \
             --progress=plain \
             -t cardano-addresses-test \
@@ -60,7 +59,7 @@ jobs:
           echo "✅ All tests passed!"
 
   build-linux-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout repository
@@ -101,7 +100,6 @@ jobs:
       - name: Build cardano-addresses for Linux ARM64
         run: |
           docker buildx build \
-            --platform linux/arm64 \
             --build-arg CARDANO_ADDRESSES_TAG=${{ steps.determine_tag.outputs.cardano_tag }} \
             --build-arg GHC_VERSION=${{ github.event.inputs.ghc_version || '9.10.1' }} \
             --build-arg CABAL_VERSION=${{ github.event.inputs.cabal_version || '3.12.1.0' }} \
@@ -137,7 +135,7 @@ jobs:
 
   release:
     needs: build-linux-arm64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Determine release tag


### PR DESCRIPTION
## Summary
• Switch from ubuntu-latest to ubuntu-22.04-arm for all CI jobs
• Remove unnecessary --platform flags (native ARM64 builds)
• Update cache scope to test-arm64 for consistency
• Fix platform mismatch errors that caused build failures

## Changes
- All jobs now use `ubuntu-22.04-arm` runners
- Removed `--platform linux/arm64` flags (not needed on native runners)
- Updated test cache scope from `test-amd64` to `test-arm64`

## Test plan
- [x] Workflow YAML is valid
- [ ] Test build should work without platform mismatch errors
- [ ] ARM64 binaries should build natively without emulation

🤖 Generated with [Claude Code](https://claude.ai/code)