### PR TITLE
Fix binary extraction permission error

### DIFF
--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Extract binary from container
         run: |
           mkdir -p artifacts
-          docker run --rm -v $(pwd)/artifacts:/output cardano-addresses-builder sh -c "cp /usr/local/bin/cardano-addresses /output/"
+          docker run --rm --user root -v $(pwd)/artifacts:/output cardano-addresses-builder sh -c "cp /usr/local/bin/cardano-addresses /output/"
           
       - name: Verify binary
         run: |


### PR DESCRIPTION
## Summary
Fixes permission denied error when extracting binary from container.

## Changes
- Add `--user root` flag to docker run command for binary extraction
- Resolves volume mount permission issues between container and host

## Test plan
- [x] Workflow YAML is valid
- [ ] Binary extraction should work without permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)