### PR TITLE
Fix GitHub release permissions

### DIFF
--- a/.github/workflows/build-cardano-addresses.yml
+++ b/.github/workflows/build-cardano-addresses.yml
@@ -1,5 +1,8 @@
 name: Build Cardano Addresses
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
## Summary
Adds required permissions for GITHUB_TOKEN to create releases.

## Changes
- Add `permissions.contents: write` to workflow
- Fixes 403 "Resource not accessible by integration" error

## Test plan
- [x] Workflow YAML is valid
- [ ] Release creation should work after merge

🤖 Generated with [Claude Code](https://claude.ai/code)