### PR TITLE
feat: add bech32 binary support for ARM64 Linux

### DIFF
--- a/.github/workflows/build-bech32.yml
+++ b/.github/workflows/build-bech32.yml
@@ -1,0 +1,188 @@
+name: Build Bech32
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'bech32-*'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile.bech32-*'
+      - '.github/workflows/build-bech32.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Bech32 tag/branch to build (e.g., 1.1.7)'
+        required: true
+        default: 'master'
+      ghc_version:
+        description: 'GHC version to use'
+        required: false
+        default: '9.10.1'
+      cabal_version:
+        description: 'Cabal version to use'
+        required: false
+        default: '3.12.1.0'
+
+jobs:
+  test-build:
+    runs-on: ubuntu-22.04-arm
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test build bech32 for Linux ARM64
+        run: |
+          docker buildx build \
+            --build-arg BECH32_TAG=1.1.7 \
+            --build-arg GHC_VERSION=9.10.1 \
+            --build-arg CABAL_VERSION=3.12.1.0 \
+            --cache-from=type=gha,scope=test-bech32-arm64 \
+            --cache-to=type=gha,mode=max,scope=test-bech32-arm64 \
+            -f Dockerfile.bech32-linux-arm64 \
+            --progress=plain \
+            -t bech32-test \
+            --load .
+
+      - name: Test binary functionality
+        run: |
+          echo "Testing bech32 binary..."
+          docker run --rm bech32-test bech32 --version
+          echo "Testing help command..."
+          docker run --rm bech32-test bech32 --help
+          echo "Testing user permissions..."
+          docker run --rm bech32-test whoami
+          echo "✅ All tests passed!"
+
+  build-linux-arm64:
+    runs-on: ubuntu-22.04-arm
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine bech32 tag
+        id: determine_tag
+        run: |
+          set -euo pipefail
+          
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Extract version from binary-specific tag (e.g., bech32-1.1.7 -> 1.1.7)
+            TAG_NAME="${{ github.ref_name }}"
+            if [[ "$TAG_NAME" == bech32-* ]]; then
+              BECH32_TAG="${TAG_NAME#bech32-}"
+              if [ -z "$BECH32_TAG" ]; then
+                echo "Error: Invalid tag format - version part is empty"
+                exit 1
+              fi
+            else
+              echo "Error: Tag must start with 'bech32-', got: $TAG_NAME"
+              exit 1
+            fi
+          else
+            BECH32_TAG="${{ github.event.inputs.tag }}"
+            if [ -z "$BECH32_TAG" ]; then
+              echo "Error: Tag input cannot be empty"
+              exit 1
+            fi
+          fi
+          
+          echo "bech32_tag=$BECH32_TAG" >> $GITHUB_OUTPUT
+          echo "✅ Building bech32 from tag/branch: $BECH32_TAG"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build bech32 for Linux ARM64
+        run: |
+          docker buildx build \
+            --build-arg BECH32_TAG=${{ steps.determine_tag.outputs.bech32_tag }} \
+            --build-arg GHC_VERSION=${{ github.event.inputs.ghc_version || '9.10.1' }} \
+            --build-arg CABAL_VERSION=${{ github.event.inputs.cabal_version || '3.12.1.0' }} \
+            --cache-from=type=gha,scope=build-bech32-arm64 \
+            --cache-to=type=gha,mode=max,scope=build-bech32-arm64 \
+            -f Dockerfile.bech32-linux-arm64 \
+            -t bech32-builder \
+            --load .
+
+      - name: Extract binary from container
+        run: |
+          mkdir -p artifacts
+          docker run --rm --user root -v $(pwd)/artifacts:/output bech32-builder sh -c "cp /usr/local/bin/bech32 /output/"
+          
+      - name: Verify binary
+        run: |
+          file artifacts/bech32
+          ls -la artifacts/
+
+      - name: Compress binary
+        run: |
+          cd artifacts
+          tar -czf bech32-linux-arm64.tar.gz bech32
+          sha256sum bech32-linux-arm64.tar.gz > bech32-linux-arm64.tar.gz.sha256
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bech32-linux-arm64
+          path: |
+            artifacts/bech32-linux-arm64.tar.gz
+            artifacts/bech32-linux-arm64.tar.gz.sha256
+
+  release:
+    needs: build-linux-arm64
+    runs-on: ubuntu-22.04-arm
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Determine release tag
+        id: release_tag
+        run: |
+          set -euo pipefail
+          
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG_NAME="${{ github.ref_name }}"
+            if [[ "$TAG_NAME" == bech32-* ]]; then
+              BECH32_TAG="${TAG_NAME#bech32-}"
+            else
+              BECH32_TAG="$TAG_NAME"
+            fi
+          else
+            BECH32_TAG="${{ github.event.inputs.tag }}"
+          fi
+          
+          echo "bech32_tag=$BECH32_TAG" >> $GITHUB_OUTPUT
+          echo "✅ Release tag determined: $BECH32_TAG"
+          
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display structure of downloaded files
+        run: find artifacts -type f
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: Bech32 ${{ steps.release_tag.outputs.bech32_tag }}
+          body: |
+            Compiled binary release for bech32 v${{ steps.release_tag.outputs.bech32_tag }}.
+            
+            **Download:** `bech32-linux-arm64.tar.gz`  
+            **Verify:** `sha256sum -c bech32-linux-arm64.tar.gz.sha256`  
+            **Extract:** `tar -xzf bech32-linux-arm64.tar.gz`  
+            **Run:** `./bech32 --version`
+          files: |
+            artifacts/**/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.bech32-linux-arm64
+++ b/Dockerfile.bech32-linux-arm64
@@ -1,0 +1,97 @@
+FROM ubuntu:22.04
+
+# Metadata
+LABEL org.opencontainers.image.title="Bech32 Builder"
+LABEL org.opencontainers.image.description="Multi-stage build for bech32 binary"
+LABEL org.opencontainers.image.source="https://github.com/SAIB-Inc/cardano-binaries"
+
+# Build arguments for version control
+ARG BECH32_TAG=master
+ARG GHC_VERSION=9.10.1
+ARG CABAL_VERSION=3.12.1.0
+
+# Install build dependencies (only what's needed)
+RUN apt-get update && apt-get install -y \
+    automake \
+    build-essential \
+    pkg-config \
+    libffi-dev \
+    libgmp-dev \
+    libssl-dev \
+    libtinfo-dev \
+    libsystemd-dev \
+    zlib1g-dev \
+    make \
+    g++ \
+    git \
+    libncurses-dev \
+    libtool \
+    autoconf \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install GHC and Cabal
+ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+ENV PATH="/root/.ghcup/bin:$PATH"
+
+# Install specific versions used by IntersectMBO
+RUN ghcup install ghc ${GHC_VERSION} && \
+    ghcup set ghc ${GHC_VERSION} && \
+    ghcup install cabal ${CABAL_VERSION} && \
+    ghcup set cabal ${CABAL_VERSION}
+
+# Clone the bech32 repository at specific tag/branch
+WORKDIR /build
+RUN git clone https://github.com/input-output-hk/bech32.git && \
+    cd bech32 && \
+    git checkout ${BECH32_TAG}
+
+WORKDIR /build/bech32
+
+# Configure cabal to use system dependencies
+RUN cabal configure --enable-executable-static
+
+# Update cabal and build (only executables, skip tests)
+RUN cabal update && \
+    cabal build exe:bech32
+
+# List and copy the built binary
+RUN mkdir -p /output && \
+    cp $(cabal list-bin exe:bech32) /output/bech32
+
+# Verify the binary works
+RUN /output/bech32 --version
+
+# Create final minimal image
+FROM ubuntu:22.04
+
+# Metadata for final image
+LABEL org.opencontainers.image.title="Bech32"
+LABEL org.opencontainers.image.description="Bech32 encoding/decoding tool"
+LABEL org.opencontainers.image.source="https://github.com/SAIB-Inc/cardano-binaries"
+LABEL org.opencontainers.image.vendor="SAIB Inc"
+
+# Install only runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libgmp10 \
+    libssl3 \
+    libtinfo6 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Create non-root user
+RUN groupadd -r bech32 && useradd -r -g bech32 -s /bin/bash bech32
+
+# Copy binary and set permissions
+COPY --from=0 /output/bech32 /usr/local/bin/bech32
+RUN chmod +x /usr/local/bin/bech32
+
+# Switch to non-root user
+USER bech32
+WORKDIR /home/bech32
+
+CMD ["bech32", "--version"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Building Cardano tools from source is frustrating:
 | Tool | Description | Platforms |
 |------|-------------|-----------|
 | **cardano-addresses** | Derive and validate Cardano addresses | ARM64 Linux (Raspberry Pi) |
+| **bech32** | Encode/decode Bech32 address format | ARM64 Linux (Raspberry Pi) |
 | cardano-cli | *Coming soon* | - |
 | cardano-node | *Coming soon* | - |
 
@@ -47,6 +48,10 @@ We use binary-specific tags to trigger automated builds:
 # Release cardano-addresses version 4.0.0
 git tag cardano-addresses-4.0.0
 git push origin cardano-addresses-4.0.0
+
+# Release bech32 version 1.1.7
+git tag bech32-1.1.7
+git push origin bech32-1.1.7
 ```
 
 This automatically:
@@ -59,6 +64,7 @@ This automatically:
 | Tool | Linux ARM64 | Linux x64 | macOS | Windows |
 |------|-------------|-----------|-------|---------|
 | cardano-addresses | ✅ | 🚧 | 🚧 | 🚧 |
+| bech32 | ✅ | 🚧 | 🚧 | 🚧 |
 | cardano-cli | 🚧 | 🚧 | 🚧 | 🚧 |
 | cardano-node | 🚧 | 🚧 | 🚧 | 🚧 |
 


### PR DESCRIPTION
## Summary
• Add support for building bech32 binaries on ARM64 Linux
• Complete CI/CD pipeline for automated releases
• Uses input-output-hk/bech32 repository as source

## Changes
- `Dockerfile.bech32-linux-arm64` - Docker build for bech32 tool
- `.github/workflows/build-bech32.yml` - Automated build and release workflow
- Updated README with bech32 information and examples

## Features
- ARM64 Linux support (Raspberry Pi)
- Tag-based releases (`bech32-1.1.7`)
- Automated testing in PRs
- GitHub release creation with binaries and checksums

## Test plan
- [x] Dockerfile builds successfully
- [x] Workflow YAML is valid
- [ ] Test build on PR merge
- [ ] Release build on tag push

🤖 Generated with [Claude Code](https://claude.ai/code)