### PR TITLE
fix: add v prefix to bech32 git tags for proper checkout

### DIFF
--- a/.github/workflows/build-bech32.yml
+++ b/.github/workflows/build-bech32.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test build bech32 for Linux ARM64
         run: |
           docker buildx build \
-            --build-arg BECH32_TAG=1.1.7 \
+            --build-arg BECH32_TAG=v1.1.7 \
             --build-arg GHC_VERSION=9.10.1 \
             --build-arg CABAL_VERSION=3.12.1.0 \
             --cache-from=type=gha,scope=test-bech32-arm64 \
@@ -74,14 +74,15 @@ jobs:
           set -euo pipefail
           
           if [ "${{ github.event_name }}" = "push" ]; then
-            # Extract version from binary-specific tag (e.g., bech32-1.1.7 -> 1.1.7)
+            # Extract version from binary-specific tag (e.g., bech32-1.1.7 -> v1.1.7)
             TAG_NAME="${{ github.ref_name }}"
             if [[ "$TAG_NAME" == bech32-* ]]; then
-              BECH32_TAG="${TAG_NAME#bech32-}"
-              if [ -z "$BECH32_TAG" ]; then
+              VERSION="${TAG_NAME#bech32-}"
+              if [ -z "$VERSION" ]; then
                 echo "Error: Invalid tag format - version part is empty"
                 exit 1
               fi
+              BECH32_TAG="v${VERSION}"
             else
               echo "Error: Tag must start with 'bech32-', got: $TAG_NAME"
               exit 1


### PR DESCRIPTION
## Summary
Fixes git checkout error in bech32 builds due to incorrect tag format.

## Problem
- bech32 repository uses v-prefixed tags (v1.1.7)
- Our workflow was trying to checkout bare version (1.1.7)
- Caused "pathspec did not match any file(s)" error

## Solution
- Update tag determination logic to add v prefix
- Convert bech32-1.1.7 → v1.1.7 for git checkout
- Fix test build to use correct tag format

## Test plan
- [x] Workflow YAML is valid
- [ ] bech32 build should complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)